### PR TITLE
Fix: Critical regression - empty prefixes and VLANs in tfvars output

### DIFF
--- a/netbox-client/scripts/test_render_tfvars.py
+++ b/netbox-client/scripts/test_render_tfvars.py
@@ -433,6 +433,27 @@ def test_build_vlan_site_mapping():
     print("✅ test_build_vlan_site_mapping passed")
 
 
+def test_build_vlan_id_to_site_mapping():
+    """Test building internal VLAN ID to site mapping."""
+    vlans = [
+        {"id": 180, "vid": 10, "site": {"slug": "pennington"}},
+        {"id": 187, "vid": 10, "site": {"slug": "countfleetcourt"}},
+        {"id": 190, "vid": 20, "site": {"slug": "pennington"}},
+        {"vid": 30, "site": {"slug": "pennington"}},  # No ID
+    ]
+
+    mapping = render_tfvars.build_vlan_id_to_site_mapping(vlans)
+
+    # Should map internal IDs to sites
+    assert mapping[180] == "pennington"
+    assert mapping[187] == "countfleetcourt"
+    assert mapping[190] == "pennington"
+    # VLAN without ID should not be in mapping
+    assert 30 not in mapping
+
+    print("✅ test_build_vlan_id_to_site_mapping passed")
+
+
 def test_extract_prefix_site_via_vlan():
     """Test prefix site extraction via VLAN association."""
     prefix = {
@@ -444,8 +465,9 @@ def test_extract_prefix_site_via_vlan():
         ("pennington", 10): "pennington",
         ("other-site", 20): "other-site",
     }
+    vlan_id_to_site = {}
 
-    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping)
+    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping, vlan_id_to_site)
     assert site == "pennington"
 
     print("✅ test_extract_prefix_site_via_vlan passed")
@@ -459,9 +481,10 @@ def test_extract_prefix_site_direct():
         "vlan": 10,
     }
     vlan_mapping = {}
+    vlan_id_to_site = {}
 
     # Should use direct site field, not VLAN lookup
-    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping)
+    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping, vlan_id_to_site)
     assert site == "pennington"
 
     print("✅ test_extract_prefix_site_direct passed")
@@ -474,11 +497,32 @@ def test_extract_prefix_site_no_match():
         "vlan": None,  # No VLAN
     }
     vlan_mapping = {10: "site-a"}
+    vlan_id_to_site = {}
 
-    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping)
+    site = render_tfvars.extract_prefix_site(prefix, vlan_mapping, vlan_id_to_site)
     assert site is None
 
     print("✅ test_extract_prefix_site_no_match passed")
+
+
+def test_extract_prefix_site_sparse_vlan():
+    """Test prefix site extraction with sparse VLAN reference (no site field)."""
+    # Real-world case: VLAN object in prefix only has id/vid/name, no site!
+    prefix = {
+        "prefix": "10.1.10.0/24",
+        "vlan": {"id": 180, "vid": 10, "name": "LAN"},  # Sparse, no site!
+    }
+
+    # Composite key mapping (used for full VLAN objects)
+    vlan_site_mapping = {("pennington", 10): "pennington"}
+
+    # Internal ID mapping (used for sparse VLAN references)
+    vlan_id_to_site = {180: "pennington"}
+
+    site = render_tfvars.extract_prefix_site(prefix, vlan_site_mapping, vlan_id_to_site)
+    assert site == "pennington"
+
+    print("✅ test_extract_prefix_site_sparse_vlan passed")
 
 
 def test_filter_resources_by_site_prefixes():
@@ -490,9 +534,10 @@ def test_filter_resources_by_site_prefixes():
     ]
     # Composite key mapping
     vlan_mapping = {("site-a", 10): "site-a", ("site-b", 20): "site-b"}
+    vlan_id_to_site = {}
 
     filtered = render_tfvars.filter_resources_by_site(
-        prefixes, "site-a", "Site A", "prefix", vlan_mapping
+        prefixes, "site-a", "Site A", "prefix", vlan_mapping, vlan_id_to_site
     )
 
     assert len(filtered) == 1
@@ -557,12 +602,20 @@ def test_end_to_end_with_netbox_api_format():
         # Load data
         loaded_data = render_tfvars.load_netbox_export(input_file=input_file)
 
-        # Build VLAN mapping
+        # Build VLAN mappings
         vlan_mapping = render_tfvars.build_vlan_site_mapping(loaded_data["vlans"])
+        vlan_id_to_site = render_tfvars.build_vlan_id_to_site_mapping(
+            loaded_data["vlans"]
+        )
 
         # Filter prefixes for Pennington site
         site_prefixes = render_tfvars.filter_resources_by_site(
-            loaded_data["prefixes"], "pennington", "Pennington", "prefix", vlan_mapping
+            loaded_data["prefixes"],
+            "pennington",
+            "Pennington",
+            "prefix",
+            vlan_mapping,
+            vlan_id_to_site,
         )
 
         # Verify the prefix was matched
@@ -592,12 +645,20 @@ def test_backward_compatibility_minimal_schema():
         # Load data
         loaded_data = render_tfvars.load_netbox_export(input_file=input_file)
 
-        # Build VLAN mapping
+        # Build VLAN mappings
         vlan_mapping = render_tfvars.build_vlan_site_mapping(loaded_data["vlans"])
+        vlan_id_to_site = render_tfvars.build_vlan_id_to_site_mapping(
+            loaded_data["vlans"]
+        )
 
         # Filter prefixes for site-a
         site_prefixes = render_tfvars.filter_resources_by_site(
-            loaded_data["prefixes"], "site-a", "site-a", "prefix", vlan_mapping
+            loaded_data["prefixes"],
+            "site-a",
+            "site-a",
+            "prefix",
+            vlan_mapping,
+            vlan_id_to_site,
         )
 
         # Verify the prefix was matched (using direct site field, not VLAN)
@@ -637,12 +698,20 @@ def test_vlans_without_prefixes_filtered():
         # Load data
         loaded_data = render_tfvars.load_netbox_export(input_file=input_file)
 
-        # Build VLAN mapping
+        # Build VLAN mappings
         vlan_mapping = render_tfvars.build_vlan_site_mapping(loaded_data["vlans"])
+        vlan_id_to_site = render_tfvars.build_vlan_id_to_site_mapping(
+            loaded_data["vlans"]
+        )
 
         # Filter prefixes and VLANs
         site_prefixes = render_tfvars.filter_resources_by_site(
-            loaded_data["prefixes"], "test-site", "test-site", "prefix", vlan_mapping
+            loaded_data["prefixes"],
+            "test-site",
+            "test-site",
+            "prefix",
+            vlan_mapping,
+            vlan_id_to_site,
         )
         site_vlans = render_tfvars.filter_resources_by_site(
             loaded_data["vlans"], "test-site", "test-site", "vlan"
@@ -739,8 +808,11 @@ def test_end_to_end_no_cross_site_prefixes():
 
         loaded_data = render_tfvars.load_netbox_export(input_file=input_file)
 
-        # Build VLAN mapping (should not raise error)
+        # Build VLAN mappings (should not raise error)
         vlan_mapping = render_tfvars.build_vlan_site_mapping(loaded_data["vlans"])
+        vlan_id_to_site = render_tfvars.build_vlan_id_to_site_mapping(
+            loaded_data["vlans"]
+        )
 
         # Filter prefixes for Pennington
         penn_prefixes = render_tfvars.filter_resources_by_site(
@@ -749,6 +821,7 @@ def test_end_to_end_no_cross_site_prefixes():
             "Pennington",
             "prefix",
             vlan_mapping,
+            vlan_id_to_site,
         )
 
         # Should have only Pennington's prefix, not Count Fleet Court's
@@ -762,6 +835,7 @@ def test_end_to_end_no_cross_site_prefixes():
             "Count Fleet Court",
             "prefix",
             vlan_mapping,
+            vlan_id_to_site,
         )
 
         # Should have only CFC's prefix, not Pennington's
@@ -769,6 +843,60 @@ def test_end_to_end_no_cross_site_prefixes():
         assert cfc_prefixes[0]["prefix"] == "10.2.10.0/24"
 
     print("✅ test_end_to_end_no_cross_site_prefixes passed")
+
+
+def test_end_to_end_sparse_vlan_references():
+    """Test full workflow with sparse VLAN references in prefixes."""
+    test_data = {
+        "sites": [{"name": "Pennington", "slug": "pennington"}],
+        "vlans": [
+            # Full VLAN object with site info
+            {
+                "id": 180,
+                "vid": 10,
+                "name": "LAN",
+                "site": {"slug": "pennington", "name": "Pennington"},
+            }
+        ],
+        "prefixes": [
+            {
+                "prefix": "10.1.10.0/24",
+                # Sparse VLAN reference - only has id/vid/name, NO site
+                "vlan": {"id": 180, "vid": 10, "name": "LAN"},
+                "description": "Home network",
+            }
+        ],
+        "tags": [],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_file = Path(tmpdir) / "input.json"
+        with open(input_file, "w") as f:
+            json.dump(test_data, f)
+
+        loaded_data = render_tfvars.load_netbox_export(input_file=input_file)
+
+        # Build both mappings
+        vlan_site_mapping = render_tfvars.build_vlan_site_mapping(loaded_data["vlans"])
+        vlan_id_to_site = render_tfvars.build_vlan_id_to_site_mapping(
+            loaded_data["vlans"]
+        )
+
+        # Filter prefixes - should work with sparse VLAN reference
+        penn_prefixes = render_tfvars.filter_resources_by_site(
+            loaded_data["prefixes"],
+            "pennington",
+            "Pennington",
+            "prefix",
+            vlan_site_mapping,
+            vlan_id_to_site,
+        )
+
+        # Should successfully match the prefix
+        assert len(penn_prefixes) == 1
+        assert penn_prefixes[0]["prefix"] == "10.1.10.0/24"
+
+    print("✅ test_end_to_end_sparse_vlan_references passed")
 
 
 def run_all_tests():
@@ -792,9 +920,11 @@ def run_all_tests():
         test_load_netbox_export_from_directory,
         test_json_keys_are_sorted,
         test_build_vlan_site_mapping,
+        test_build_vlan_id_to_site_mapping,
         test_extract_prefix_site_via_vlan,
         test_extract_prefix_site_direct,
         test_extract_prefix_site_no_match,
+        test_extract_prefix_site_sparse_vlan,
         test_filter_resources_by_site_prefixes,
         test_filter_resources_by_site_vlans,
         test_end_to_end_with_netbox_api_format,
@@ -803,6 +933,7 @@ def run_all_tests():
         test_extract_vlan_vid,
         test_composite_key_mapping_same_vid_different_sites,
         test_end_to_end_no_cross_site_prefixes,
+        test_end_to_end_sparse_vlan_references,
     ]
 
     passed = 0


### PR DESCRIPTION
## Problem

After merging PR #105 (composite key fix), the Pennington tfvars file shows empty arrays for both prefixes and VLANs despite the NetBox export data being correct.

**Evidence:**
- File: `/tmp/verify/terraform-tfvars/site-pennington.tfvars.json`
  - `"prefixes": []` (expected ~15 prefixes)
  - `"vlans": []` (expected ~15 VLANs)
- NetBox export files at `/tmp/verify/netbox-intent-export/` contain correct data

## Root Cause

The `extract_prefix_site()` function attempts to extract site information from the VLAN object embedded in prefix data. **However, this VLAN object is a sparse reference that does NOT include the `site` field**.

### Data Structure Issue

**Prefix VLAN reference (sparse):**
```yaml
vlan:
  id: 180
  vid: 10
  name: "PENN_Home_General"
  description: "..."
  url: "..."
  # NO "site" FIELD!
```

**Full VLAN object (from vlans.yaml):**
```yaml
vlan:
  id: 180
  vid: 10
  name: "PENN_Home_General"
  site:
    id: 52
    slug: "pennington"
    name: "Pennington"
```

### Failure Chain

1. **`build_vlan_site_mapping()`** correctly creates composite key mappings: `{("pennington", 10): "pennington"}` ✓
2. **`extract_prefix_site()`** fails to look up prefixes:
   - Tries `vlan.get("site")` → returns `None` (sparse object)
   - Cannot determine site, returns `None`
3. **`filter_resources_by_site()`** filters out ALL prefixes:
   - All prefixes have `site = None`
   - Filtered list is empty
4. **VLAN filtering** removes all VLANs:
   - No prefixes → empty `prefix_vlan_ids` set
   - All VLANs filtered out

## Solution

Create an additional mapping that uses VLAN internal IDs to look up sites, enabling site resolution from sparse VLAN references.

### Changes

1. **Added `build_vlan_id_to_site_mapping()` function** that maps `vlan_internal_id → site_slug`
2. **Updated `extract_prefix_site()`** to use this mapping when VLAN site is unavailable (Method 2b fallback)
3. **Updated `filter_resources_by_site()`** to accept and pass both mappings
4. **Updated `main()`** to build and pass both mappings

### Testing

- **Added 3 new tests:**
  - `test_build_vlan_id_to_site_mapping()` - Verify internal ID to site mapping
  - `test_extract_prefix_site_sparse_vlan()` - Test sparse VLAN reference resolution
  - `test_end_to_end_sparse_vlan_references()` - Full workflow test with sparse VLANs

- **Updated 8 existing tests** to pass new `vlan_id_to_site` parameter

- **Test results:** All 27 tests pass (24 existing + 3 new) ✅

### Verification

Tested with real NetBox export data:
- ✅ Pennington prefixes: 15 (was 0)
- ✅ Pennington VLANs: 15 (was 0)
- ✅ Count Fleet Court prefixes: 8 
- ✅ Count Fleet Court VLANs: 8

## Technical Details

The fix maintains the composite key approach from PR #105 for preventing VID collision issues while adding a complementary internal ID mapping for handling sparse VLAN references:

- **Composite key mapping:** `{(site_slug, vid): site_slug}` - Used when VLAN object includes site field
- **Internal ID mapping:** `{vlan_internal_id: site_slug}` - Used when VLAN object lacks site field (sparse reference)

Both mappings work together to provide complete coverage for all VLAN reference formats.