### PR TITLE
fix: Update site names and slugs for consistency across configurations

### DIFF
--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -66,30 +66,38 @@ jobs:
     # APPROVAL GATE: Only run on approved PRs or manual dispatch
     # - For PR reviews: Only process if review state is 'approved'
     # - For manual dispatch: Always allow (for testing/emergency)
-    # - Skip matrix items if a specific site was requested
     if: |
-      (
-        (github.event_name == 'workflow_dispatch') ||
-        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
-      ) && (
-        github.event_name != 'workflow_dispatch' ||
-        github.event.inputs.site == '' ||
-        github.event.inputs.site == matrix.site
-      )
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
 
     strategy:
       matrix:
         # Define sites - this could be dynamically generated in the future
-        site: [pennington, countfleetcourt]
+        site: [pennington, count-fleet-court]
       fail-fast: false
 
     steps:
+      - name: Check if site should be processed
+        id: check-site
+        run: |
+          # Skip this matrix item if a specific site was requested and it doesn't match
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ -n "${{ github.event.inputs.site }}" ] && \
+             [ "${{ github.event.inputs.site }}" != "${{ matrix.site }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping site ${{ matrix.site }} (requested: ${{ github.event.inputs.site }})"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "✅ Processing site: ${{ matrix.site }}"
+          fi
+
       - name: Checkout repository
+        if: steps.check-site.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Extract PR metadata (for approval events)
         id: pr-metadata
-        if: github.event_name == 'pull_request_review'
+        if: steps.check-site.outputs.skip != 'true' && github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -137,6 +145,7 @@ jobs:
           echo "✅ Found render run ID: $RENDER_RUN_ID"
 
       - name: Determine render run ID
+        if: steps.check-site.outputs.skip != 'true'
         id: determine-run
         env:
           GH_TOKEN: ${{ github.token }}
@@ -160,6 +169,7 @@ jobs:
           echo "✅ Will use artifacts from run: $RUN_ID"
 
       - name: Download attested artifacts
+        if: steps.check-site.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -186,6 +196,7 @@ jobs:
           ls -lh artifacts/tfvars/
 
       - name: Verify artifact attestations (REQUIRED)
+        if: steps.check-site.outputs.skip != 'true'
         id: verify-attestation
         # SECURITY BOUNDARY ENFORCEMENT:
         # This step is MANDATORY and enforces the trust boundary contract.
@@ -199,11 +210,13 @@ jobs:
           environment: 'prod'
 
       - name: Set up Terraform
+        if: steps.check-site.outputs.skip != 'true'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.0"
 
       - name: Configure Terraform provider (stub mode)
+        if: steps.check-site.outputs.skip != 'true'
         run: |
           # Use stub/empty credentials for plan-only validation
           # This allows schema validation without actual UniFi controller access
@@ -221,6 +234,7 @@ jobs:
           echo "✅ Provider configuration set"
 
       - name: Terraform Init
+        if: steps.check-site.outputs.skip != 'true'
         working-directory: terraform
         run: |
           echo "🚀 Initializing Terraform..."
@@ -241,6 +255,7 @@ jobs:
           terraform providers
 
       - name: Terraform Validate
+        if: steps.check-site.outputs.skip != 'true'
         working-directory: terraform
         run: |
           echo "✅ Validating Terraform configuration..."
@@ -254,6 +269,7 @@ jobs:
           echo "✅ Configuration is valid"
 
       - name: Terraform Plan (Binary)
+        if: steps.check-site.outputs.skip != 'true'
         id: plan
         working-directory: terraform
         continue-on-error: true
@@ -296,7 +312,7 @@ jobs:
           exit 0
 
       - name: Terraform Show (JSON)
-        if: steps.plan.outputs.plan_status != 'failed'
+        if: steps.check-site.outputs.skip != 'true' && steps.plan.outputs.plan_status != 'failed'
         working-directory: terraform
         run: |
           PLAN_FILE="tfplan-${{ matrix.site }}.binary"
@@ -317,7 +333,7 @@ jobs:
           fi
 
       - name: Generate Structured Plan Diff
-        if: steps.plan.outputs.plan_status != 'failed'
+        if: steps.check-site.outputs.skip != 'true' && steps.plan.outputs.plan_status != 'failed'
         working-directory: terraform
         run: |
           JSON_FILE="tfplan-${{ matrix.site }}.json"
@@ -344,7 +360,7 @@ jobs:
 
       - name: Evaluate Policy with OPA
         id: policy
-        if: steps.plan.outputs.plan_status != 'failed'
+        if: steps.check-site.outputs.skip != 'true' && steps.plan.outputs.plan_status != 'failed'
         working-directory: terraform
         run: |
           PLAN_JSON="tfplan-${{ matrix.site }}.json"
@@ -475,7 +491,7 @@ jobs:
           fi
 
       - name: Record Approval Requirement
-        if: steps.policy.outputs.policy_result == 'pass'
+        if: steps.check-site.outputs.skip != 'true' && steps.policy.outputs.policy_result == 'pass'
         working-directory: terraform
         run: |
           APPROVAL_REQUIRED="${{ steps.policy.outputs.approval_required }}"
@@ -497,7 +513,7 @@ jobs:
 
       - name: Upload Terraform Plans
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.check-site.outputs.skip != 'true' && always()
         with:
           name: terraform-plan-${{ matrix.site }}
           path: |
@@ -510,7 +526,7 @@ jobs:
           retention-days: 30
 
       - name: Plan Summary
-        if: always()
+        if: steps.check-site.outputs.skip != 'true' && always()
         run: |
           DIFF_FILE="terraform/tfplan-${{ matrix.site }}-diff.md"
           PR_NUM="${{ steps.determine-run.outputs.pr_number }}"

--- a/netbox-client/README.md
+++ b/netbox-client/README.md
@@ -105,8 +105,8 @@ python netbox-client/scripts/seed_netbox.py netbox-client/examples/*.yaml
 ```
 
 **Example Sites:**
-- `site-pennington` - Primary residence with 192.168.10.0/24 network
-- `site-countfleetcourt` - Secondary site with 192.168.20.0/24 network
+- `pennington` - Primary residence with 192.168.10.0/24 network
+- `count-fleet-court` - Secondary site with 192.168.20.0/24 network
 
 **What gets created:**
 - Sites with descriptions

--- a/netbox-client/examples/README.md
+++ b/netbox-client/examples/README.md
@@ -6,14 +6,14 @@ This directory contains example YAML configuration files for seeding NetBox with
 
 ### site-pennington.yaml
 Primary residence configuration:
-- **Site Name**: site-pennington
+- **Site Name**: pennington
 - **Description**: Primary residence
 - **Network**: 192.168.10.0/24
 - **VLAN ID**: 10 (Home VLAN)
 
 ### site-countfleetcourt.yaml
 Secondary site configuration:
-- **Site Name**: site-countfleetcourt
+- **Site Name**: count-fleet-court
 - **Description**: Secondary site
 - **Network**: 192.168.20.0/24
 - **VLAN ID**: 20 (Secondary VLAN)

--- a/netbox-client/examples/intent-minimal-schema.json
+++ b/netbox-client/examples/intent-minimal-schema.json
@@ -3,26 +3,26 @@
   "_description": "This file demonstrates the minimal set of NetBox objects required for basic network intent management across multiple sites.",
   "sites": [
     {
-      "name": "site-pennington",
-      "slug": "site-pennington",
+      "name": "Pennington",
+      "slug": "pennington",
       "description": "Primary residence"
     },
     {
-      "name": "site-countfleetcourt",
-      "slug": "site-countfleetcourt",
+      "name": "Count Fleet Court",
+      "slug": "count-fleet-court",
       "description": "Secondary lab site"
     }
   ],
   "prefixes": [
     {
-      "site": "site-pennington",
+      "site": "pennington",
       "prefix": "192.168.10.0/24",
       "vlan": 10,
       "description": "Home LAN",
       "status": "active"
     },
     {
-      "site": "site-countfleetcourt",
+      "site": "count-fleet-court",
       "prefix": "192.168.20.0/24",
       "vlan": 20,
       "description": "Lab network",
@@ -31,14 +31,14 @@
   ],
   "vlans": [
     {
-      "site": "site-pennington",
+      "site": "pennington",
       "vlan_id": 10,
       "name": "Home LAN",
       "description": "Default VLAN for primary residence",
       "status": "active"
     },
     {
-      "site": "site-countfleetcourt",
+      "site": "count-fleet-court",
       "vlan_id": 20,
       "name": "Guest VLAN",
       "description": "Guest network for lab site",

--- a/netbox-client/examples/intent-minimal-schema.yaml
+++ b/netbox-client/examples/intent-minimal-schema.yaml
@@ -12,23 +12,23 @@
 #   python netbox-client/scripts/post_minimal_intent.py
 
 sites:
-  - name: site-pennington
-    slug: site-pennington
+  - name: Pennington
+    slug: pennington
     description: Primary residence
 
-  - name: site-countfleetcourt
-    slug: site-countfleetcourt
+  - name: Count Fleet Court
+    slug: count-fleet-court
     description: Secondary lab site
 
 # IP prefixes define network ranges and associate them with sites and VLANs
 prefixes:
-  - site: site-pennington
+  - site: pennington
     prefix: 192.168.10.0/24
     vlan: 10
     description: Home LAN
     status: active
 
-  - site: site-countfleetcourt
+  - site: count-fleet-court
     prefix: 192.168.20.0/24
     vlan: 20
     description: Lab network
@@ -36,13 +36,13 @@ prefixes:
 
 # VLANs provide network segmentation within sites
 vlans:
-  - site: site-pennington
+  - site: pennington
     vlan_id: 10
     name: Home LAN
     description: Default VLAN for primary residence
     status: active
 
-  - site: site-countfleetcourt
+  - site: count-fleet-court
     vlan_id: 20
     name: Guest VLAN
     description: Guest network for lab site

--- a/netbox-client/examples/site-countfleetcourt.yaml
+++ b/netbox-client/examples/site-countfleetcourt.yaml
@@ -2,8 +2,8 @@
 # This file contains example configuration for the secondary site
 
 site:
-  name: site-countfleetcourt
-  slug: site-countfleetcourt
+  name: Count Fleet Court
+  slug: count-fleet-court
   description: Secondary site
 
 # IP prefixes for the site

--- a/netbox-client/examples/site-pennington.yaml
+++ b/netbox-client/examples/site-pennington.yaml
@@ -2,8 +2,8 @@
 # This file contains example configuration for the primary residence site
 
 site:
-  name: site-pennington
-  slug: site-pennington
+  name: Pennington
+  slug: pennington
   description: Primary residence
 
 # IP prefixes for the site

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -91,7 +91,7 @@ See [Trust Boundary Documentation](../docs/phase3/terraform-boundary.md) for com
 Each site has its own tfvars file generated from NetBox exports:
 
 - `site-pennington.tfvars.json` - Configuration for Pennington site
-- `site-countfleetcourt.tfvars.json` - Configuration for Count Fleet Court site
+- `site-count-fleet-court.tfvars.json` - Configuration for Count Fleet Court site
 
 These files contain:
 - Site metadata (name, slug, description)


### PR DESCRIPTION
---
name: Terraform Plan Request
about: Request Terraform plan execution for rendered artifacts
title: 'Terraform Plan: [Site Name or "All Sites"]'
labels: terraform, infrastructure
---

## Terraform Plan Request

This PR requests Terraform plan execution for the rendered artifacts from a specific render workflow run.

### Render Artifacts Source

**Render Run ID:** <!-- Replace with the workflow run ID from render-artifacts workflow -->

Or provide the full workflow run URL:
**Render Run:** <!-- https://github.com/OWNER/REPO/actions/runs/XXXXXXXXXX -->

### Sites to Plan

- [ ] All sites
- [ ] Specific site: <!-- pennington / countfleetcourt -->

### Changes Overview

<!-- Describe what infrastructure changes are expected from this plan -->

### Checklist

Before requesting approval:

- [ ] I have verified the render artifacts workflow completed successfully
- [ ] I have reviewed the rendered tfvars files from the specified run
- [ ] I understand that approving this PR will trigger Terraform plan execution
- [ ] I have verified the render run ID is correct and traceable
- [ ] This PR references attested artifacts from the official render pipeline

### Approval Requirements

**Note:** Terraform plan will automatically execute when this PR is approved by a repository maintainer.

The workflow will:
1. Extract the render run ID from this PR description
2. Download the attested artifacts from the specified workflow run
3. Verify artifact attestations (SLSA provenance)
4. Execute Terraform plan for the specified sites
5. Record full traceability: PR number, approver, artifact source, plan results

### Security & Compliance

- ✅ Uses attested artifacts only
- ✅ Enforces PR approval gate
- ✅ Full audit trail maintained
- ✅ Cannot be triggered by branch push

See [docs/phase4/security.md](../../docs/phase4/security.md) for complete security documentation.
